### PR TITLE
[Standardization] Update CODEOWNERS file to .github directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,10 @@
 # The following lines are exceptions to the above rule intended to allow Leads and the TI Platform team to manage standard functionality within the repository. 
 .circleci/* @Saildrone/ti-platform 
 .github/* @Saildrone/ti-platform @Saildrone/leads
-/deploy @Saildrone/ti-platform 
-/lambda @Saildrone/ti-platform 
-/kubernetes @Saildrone/ti-platform 
+/deploy @Saildrone/ti-platform @Saildrone/sw-platform
+/deploy/chart/* @Saildrone/ti-platform 
+/lambda @Saildrone/ti-platform @Saildrone/sw-platform
+/kubernetes @Saildrone/ti-platform @Saildrone/sw-platform
 LICENSE @Saildrone/leads 
  
 # For more fine-grained ownership within the repository, add additional lines below. 


### PR DESCRIPTION
This PR places a CODEOWNERS file in the .github directory.