### PR TITLE
relax peer deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saildrone/sequelize-serializer",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Todd Bealmear <todd@saildrone.com>",
   "license": "MIT",
   "peerDependencies": {
-    "sequelize": "^5.18.4"
+    "sequelize": "^4.44.4"
   },
   "devDependencies": {
     "@hapi/code": "^6.0.0",


### PR DESCRIPTION
Exporter Controller uses this package as a dep, but it uses Sequelize v4 without issue. Now that we're using higher versions of Node, peer dependencies are strictly enforced. We don't want to do a major version bump of Sequelize in Exporter Controller, so let's just relax the peer dep.